### PR TITLE
feat: add echo builtin command

### DIFF
--- a/cmd/goshell/main.go
+++ b/cmd/goshell/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/IshaanNene/GoShell/internal/core"
 	"github.com/spf13/cobra"
+	"github.com/IshaanNene/GoShell/internal/core"
 )
 
 func main() {
@@ -12,6 +12,7 @@ func main() {
 		Use:   "./goshell",
 		Short: "For all usage",
 	}
+	core.InitCommands(rootCmd)
 	rootCmd.AddCommand(core.LsCmd)
 	rootCmd.AddCommand(core.CdCmd)
 	rootCmd.AddCommand(core.MkdirCmd)

--- a/internal/core/echo_commands.go
+++ b/internal/core/echo_commands.go
@@ -1,0 +1,17 @@
+package core
+
+import (
+    "fmt"
+    "strings"
+
+    "github.com/spf13/cobra"
+)
+
+// EchoCmd prints its arguments separated by spaces.
+var EchoCmd = &cobra.Command{
+    Use:   "echo",
+    Short: "Print arguments to the console",
+    Run: func(cmd *cobra.Command, args []string) {
+        fmt.Println(strings.Join(args, " "))
+    },
+}

--- a/internal/core/init.go
+++ b/internal/core/init.go
@@ -13,4 +13,5 @@ func InitCommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(PwdCmd)
 	rootCmd.AddCommand(TouchCmd)
 	rootCmd.AddCommand(MkdirCmd)
+	rootCmd.AddCommand(EchoCmd)
 }


### PR DESCRIPTION
Title: feat: add echo builtin command
Description:
Summary -

Adds a new built-in echo command to the shell. The command prints its arguments joined by single spaces and outputs a trailing newline. Quoted strings are preserved by Cobra argument parsing.
Files changed:

- internal/core/echo_commands.go — new command implementation
- [main.go] - 
<img width="1128" height="207" alt="Screenshot 2025-10-17 224033" src="https://github.com/user-attachments/assets/9021d8ff-1d74-4e50-8971-e8bfcb4d2971" />
 ensures core commands are initialized and registered (call to core.InitCommands)
Behavior

Usage: ./goshell echo [args...]
Examples:
./goshell echo Hello world
Output: Hello world
./goshell echo "Hello, world!"
Output: Hello, world!