### PR TITLE
Fixed the cat command and added a new folder to store the concatenate…

### DIFF
--- a/internal/core/cat_commands.go
+++ b/internal/core/cat_commands.go
@@ -76,5 +76,4 @@ func displayFile(file string, number, numberNonBlank, squeezeBlank bool) {
 			fmt.Println(line)
 		}
 	}
-	fmt.Println()
 }


### PR DESCRIPTION
I have fixed the issue where the cat function didn't actually merge multiple files but only displayed their contents.
I also added another folder where the concatenated files are saved

<img width="1163" height="252" alt="Screenshot 2025-10-17 at 11 02 01 PM" src="https://github.com/user-attachments/assets/aedc3d11-21e0-40e1-80a2-363d357cc2a8" />

<img width="423" height="68" alt="Screenshot 2025-10-17 at 11 02 10 PM" src="https://github.com/user-attachments/assets/e019a9f0-883e-4e8b-b9ce-a39c444991ba" />
